### PR TITLE
fix: FAVA_VERSION argument not working when git checkout

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ ARG FAVA_VERSION=v1.21
 
 ARG NODE_BUILD_IMAGE=16-bullseye
 FROM node:${NODE_BUILD_IMAGE} as node_build_env
+ARG FAVA_VERSION
 
 WORKDIR /tmp/build
 RUN git clone https://github.com/beancount/fava


### PR DESCRIPTION
Since `ARG FAVA_VERSION` part is before the `FROM` clause for the Fava building environment, the argument might not take effect and will cause `RUN git checkout ${FAVA_VERSION}` always check out the current branch, and thus fail to control the Fava version through the `FAVA_VERSION` argument.