### PR TITLE
Add beancount-reds-plugins

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,8 @@ RUN git checkout ${BEANCOUNT_VERSION}
 
 RUN CFLAGS=-s pip3 install -U /tmp/build/beancount
 RUN pip3 install -U /tmp/build/fava
+ADD requirements.txt .
+RUN pip3 install --require-hashes -U -r requirements.txt
 
 RUN pip3 uninstall -y pip
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+beancount-reds-plugins==0.3.0 --hash=sha256:4bf7d56a9d8084acb50591283cf1724eaa035c2f2df2ac70a3370b0d068da6ed


### PR DESCRIPTION
Add requirements.txt as a basis for adding extensions

Fixes https://github.com/yegle/fava-docker/issues/21