### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,8 @@
 beancount-reds-plugins==0.3.0 --hash=sha256:4bf7d56a9d8084acb50591283cf1724eaa035c2f2df2ac70a3370b0d068da6ed
+beancount>=2.3.5 
+fava>=1.24 
+beancount-dkb>=0.15.0
+smart-importer>=0.4
+beancount-ing>=0.6.0
+beancount-periodic>=0.1.1
+beancount-import>=1.3.5 


### PR DESCRIPTION
I've just added my python packages. Is it desired to have the packages pinned with `==` or is it better to have just an minimum required version (`>=`) to have automatic updates of the packages?