### PR TITLE
Add beanprice to Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,7 @@ RUN CFLAGS=-s pip3 install -U /tmp/build/beancount
 RUN pip3 install -U /tmp/build/fava
 ADD requirements.txt .
 RUN pip3 install --require-hashes -U -r requirements.txt
+RUN pip3 install git+https://github.com/beancount/beanprice.git@41576e2ac889e4825e4985b6f6c56aa71de28304
 
 RUN pip3 uninstall -y pip
 


### PR DESCRIPTION
Unfortunately, [beanprice isn't on PyPi](https://github.com/beancount/beanprice/issues/3) and [hasn't had a release in years](https://github.com/beancount/beanprice/issues/84). Therefore, we have to use to just install what's in the repo...

Closes: #32