### PR TITLE
Rewrite Dockerfile for beancount version 3 and fava as frontend.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,70 +1,21 @@
-ARG BEANCOUNT_VERSION=2.3.6
-ARG FAVA_VERSION=v1.30
-
-ARG NODE_BUILD_IMAGE=22-bookworm
-FROM node:${NODE_BUILD_IMAGE} AS node_build_env
-ARG FAVA_VERSION
-
-WORKDIR /tmp/build
-RUN git clone https://github.com/beancount/fava
+FROM python:3.14.0a6
 
 RUN apt-get update
-RUN apt-get install -y python3-babel
+RUN apt-get install -y pipx
 
-WORKDIR /tmp/build/fava
-RUN git checkout ${FAVA_VERSION}
-RUN make
-RUN rm -rf .*cache && \
-    rm -rf .eggs && \
-    rm -rf .tox && \
-    rm -rf build && \
-    rm -rf dist && \
-    rm -rf frontend/node_modules && \
-    find . -type f -name '*.py[c0]' -delete && \
-    find . -type d -name "__pycache__" -delete
+RUN mkdir /app
+RUN chown 1000:1000 /app
+USER 1000:1000
 
-# Why not use `python:bookworm`? Because the final app is served by
-# distroless Python image, which is Debian + Python from Debain APT
-# repo. The python intepreter in the `python:bookworm` image is not from
-# Debian APT repo.
-FROM debian:bookworm AS build_env
-ARG BEANCOUNT_VERSION
-
-RUN apt-get update
-RUN apt-get install -y build-essential libxml2-dev libxslt-dev curl \
-        python3 libpython3-dev python3-pip git python3-venv
-
-
-ENV PATH="/app/bin:$PATH"
-RUN python3 -mvenv /app
-COPY --from=node_build_env /tmp/build/fava /tmp/build/fava
-
-WORKDIR /tmp/build
-RUN git clone https://github.com/beancount/beancount
-
-WORKDIR /tmp/build/beancount
-RUN git checkout ${BEANCOUNT_VERSION}
-
-RUN CFLAGS=-s pip3 install -U /tmp/build/beancount
-RUN pip3 install -U /tmp/build/fava
-ADD requirements.txt .
-RUN pip3 install --require-hashes -U -r requirements.txt
-RUN pip3 install git+https://github.com/beancount/beanprice.git@41576e2ac889e4825e4985b6f6c56aa71de28304
-RUN pip3 install git+https://github.com/andreasgerstmayr/fava-portfolio-returns.git@de68b54f3ac517adfde3a4ccb41fdb09a0da41d1
-
-RUN pip3 uninstall -y pip
-
-RUN find /app -name __pycache__ -exec rm -rf -v {} +
-
-FROM gcr.io/distroless/python3-debian12
-COPY --from=build_env /app /app
-
-# Default fava port number
-EXPOSE 5000
+ENV PIPX_HOME="/app"
+ENV PIPX_BIN_DIR="/app/bin"
+RUN pipx install beancount==3.1.0
+RUN pipx install beanquery==v0.2.0
+RUN pipx install fava==v1.30.2
 
 ENV BEANCOUNT_FILE=""
 
 ENV FAVA_HOST="0.0.0.0"
-ENV PATH="/app/bin:$PATH"
+ENV PATH=/app/bin:$PATH
 
 ENTRYPOINT ["fava"]


### PR DESCRIPTION
This PR is to get the discussion going for upgrading to version 3 of beancount.

In version 3 beancount has been split in several parts such that we need
* beancount
* beanquery
* fava as usual

I used the python image as base since I think that is all we need. After fulfilling system upgrade and install everything is executed as normal user.
Installation of the venv is done to /installspace.
Ledger files shall be mounted in the container to /workspace.
The default ledger name is "main.beancount".

On startup of the container you have to provide
* `-e BEANCOUNT_FILE="yourLedgerFile"`
* `-v /path/to/your/ledger/data:/bean`
* `-p 5000:5000`

If you guys like the general direction I will add other dependencies which are currently missing.


